### PR TITLE
Admin dashboard closes #46

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -26,7 +26,7 @@ class Admin::ItemsController < Admin::BaseController
     item.update(item_params)
     if item.save
       flash[:notice] = "#{item.title} succesfully updated"
-      redirect_to admin_items_path(item)
+      redirect_to admin_items_path
     else
       render :'items#index'
     end

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -1,10 +1,11 @@
 class Admin::ItemsController < Admin::BaseController
+  before_action :set_item, only: [:edit, :update, :show]
+
   def index
     @items = Item.all
   end
 
   def show
-    @item = Item.find_by(slug: params[:title])
   end
 
   def new
@@ -21,12 +22,14 @@ class Admin::ItemsController < Admin::BaseController
     end
   end
 
+  def edit
+  end
+
   def update
-    item = Item.find(params[:title])
-    item.update(item_params)
-    if item.save
-      flash[:notice] = "#{item.title} succesfully updated"
-      redirect_to admin_items_path
+    @item.update(item_params)
+    if @item.save
+      flash[:notice] = "#{@item.title} succesfully updated"
+      redirect_to admin_item_path(@item)
     else
       render :'items#index'
     end
@@ -35,5 +38,9 @@ class Admin::ItemsController < Admin::BaseController
   private
     def item_params
       params.require(:item).permit(:title, :description, :price, :image, :status)
+    end
+
+    def set_item
+      @item = Item.find(params[:id])
     end
 end

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -16,7 +16,7 @@ class Admin::ItemsController < Admin::BaseController
     item = Item.new(item_params)
     if item.save
       flash[:notice] = "#{item.title} created succesfully"
-      redirect_to '/bike-shop'
+      redirect_to admin_items_path
     else
       render :new
     end
@@ -29,7 +29,7 @@ class Admin::ItemsController < Admin::BaseController
     @item.update(item_params)
     if @item.save
       flash[:notice] = "#{@item.title} succesfully updated"
-      redirect_to admin_item_path(@item)
+      redirect_to admin_items_path
     else
       render :'items#index'
     end

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -3,6 +3,10 @@ class Admin::ItemsController < Admin::BaseController
     @items = Item.all
   end
 
+  def show
+    @item = Item.find_by(slug: params[:title])
+  end
+
   def new
     @item = Item.new
   end
@@ -18,12 +22,11 @@ class Admin::ItemsController < Admin::BaseController
   end
 
   def update
-    binding.pry
-    item = Item.find_by(slug: params[:title])
+    item = Item.find(params[:title])
     item.update(item_params)
     if item.save
       flash[:notice] = "#{item.title} succesfully updated"
-      redirect_to bike_shop_path(item)
+      redirect_to admin_items_path(item)
     else
       render :'items#index'
     end
@@ -31,6 +34,6 @@ class Admin::ItemsController < Admin::BaseController
 
   private
     def item_params
-      params.require(:item).permit(:title, :description, :price, :image)
+      params.require(:item).permit(:title, :description, :price, :image, :status)
     end
 end

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -17,6 +17,18 @@ class Admin::ItemsController < Admin::BaseController
     end
   end
 
+  def update
+    binding.pry
+    item = Item.find_by(slug: params[:title])
+    item.update(item_params)
+    if item.save
+      flash[:notice] = "#{item.title} succesfully updated"
+      redirect_to bike_shop_path(item)
+    else
+      render :'items#index'
+    end
+  end
+
   private
     def item_params
       params.require(:item).permit(:title, :description, :price, :image)

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -5,13 +5,8 @@ class CartsController < ApplicationController
     @item = Item.find(params[:item_id])
     @cart.add_item(params[:item_id])
     session[:cart] = @cart.contents
-<<<<<<< HEAD
     flash[:success] = "You now have #{pluralize(session[:cart][@item.id.to_s], @item.title)} in your cart"
-    redirect_to bike_shop_path
-=======
-    flash[:success] = "You now have #{pluralize(session[:cart][item.id.to_s], item.title)} in your cart"
     redirect_to items_path
->>>>>>> remove item slug, change bike-shop routes to items, add admin item edit view action and tests
   end
 
   def remove_item

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -5,8 +5,13 @@ class CartsController < ApplicationController
     @item = Item.find(params[:item_id])
     @cart.add_item(params[:item_id])
     session[:cart] = @cart.contents
+<<<<<<< HEAD
     flash[:success] = "You now have #{pluralize(session[:cart][@item.id.to_s], @item.title)} in your cart"
     redirect_to bike_shop_path
+=======
+    flash[:success] = "You now have #{pluralize(session[:cart][item.id.to_s], item.title)} in your cart"
+    redirect_to items_path
+>>>>>>> remove item slug, change bike-shop routes to items, add admin item edit view action and tests
   end
 
   def remove_item

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,6 +4,6 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find_by(slug: params[:title])
+    @item = Item.find(params[:id])
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -21,5 +21,4 @@ class SessionsController < ApplicationController
     flash[:success] = "Successfully Logged Out"
     redirect_to root_path
   end
-
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,4 @@
 class Item < ApplicationRecord
-  before_save :generate_slug
-  enum status: %w(active retired)
   has_attached_file :image,
                     styles: { thumb: ['64x64#', :jpg],
                               original: ['500x500>', :jpg] },
@@ -15,7 +13,11 @@ class Item < ApplicationRecord
   validates_uniqueness_of :title
   validates_numericality_of :price
 
-  def generate_slug
-    self.slug = self.title.parameterize
+  def retired?
+    status == 'retired'
+  end
+
+  def active?
+    status == 'active'
   end
 end

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -13,5 +13,5 @@
       <%= content_tag(:option, c, value: index) %>
     <% end %>
   <% end %>
-  <%= f.submit "Create Accessory" %>
+  <%= yield f %>
 <% end %>

--- a/app/views/admin/items/_item.html.erb
+++ b/app/views/admin/items/_item.html.erb
@@ -1,0 +1,15 @@
+<tr>
+  <th><%= link_to image_tag(item.image.url, class: 'media-object'), item.image.url, target: '_blank' %></th>
+  <th><%= link_to item.title, item_path(item) %></th>
+  <th>$<%= item.price %></th>
+  <th><%= item.description %></th>
+  <th><%= item.status %></th>
+  <th>
+      <%= link_to "Edit", edit_admin_item_path(item), class: "edit-#{item.id}" %>
+      <% if item.active? %>
+        <%= button_to 'Retire', admin_item_path(item, item: {status: 'retired'}), method: :put, class: "retire-#{item.id}" %>
+      <% elsif item.retired? %>
+        <%= link_to 'Reactivate', admin_item_path(item, item: {status: 'active'}), method: :put, class: "reactivate-#{item.id}" %>
+      <% end %>
+  </th>
+</tr>

--- a/app/views/admin/items/edit.html.erb
+++ b/app/views/admin/items/edit.html.erb
@@ -1,2 +1,4 @@
 <h1>Update Accessory</h1>
-<%= render partial: 'form' %>
+<%= render 'form' do |f| %>
+  <%= f.submit 'Update Accessory' %>
+<% end %>

--- a/app/views/admin/items/edit.html.erb
+++ b/app/views/admin/items/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>Update Accessory</h1>
+<%= render partial: 'form' %>

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -1,2 +1,16 @@
 <h1>Bike Shop</h1>
-<%= render partial: 'items/item', collection: @items %>
+<table class="table">
+  <thead>
+    <tr>
+      <th scope="col">#</th>
+      <th scope="col">Title</th>
+      <th scope="col">Price $</th>
+      <th scope="col">Description</th>
+      <th scope="col">Status</th>
+      <th scope="col">Options</th>
+    </tr>
+  </thead>
+  <tbody>
+    <%= render @items %>
+</tbody>
+</table>

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Bike Shop</h1>
+<%= render partial: 'items/item', collection: @items %>

--- a/app/views/admin/items/new.html.erb
+++ b/app/views/admin/items/new.html.erb
@@ -1,2 +1,4 @@
 <h1>Create a New Accessory</h1>
-<%= render partial: 'form' %>
+<%= render 'form' do |f| %>
+  <%= f.submit 'Create Accessory' %>
+<% end %>

--- a/app/views/admin/items/show.html.erb
+++ b/app/views/admin/items/show.html.erb
@@ -1,1 +1,0 @@
-<%= render partial: 'items/item', object: @item %>

--- a/app/views/admin/items/show.html.erb
+++ b/app/views/admin/items/show.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: 'items/item', object: @item %>

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -14,7 +14,7 @@
     <p>Accessory Retired</p>
   <% end %>
   <% if current_admin? %>
-    <div class="item-<%= item.slug %>">
+    <div class="item-<%= item.id %>">
       <%= item.status %>
       <%= link_to "Edit", edit_admin_item_path(item) %>
       <% if item.active? %>

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -2,7 +2,7 @@
   <%= link_to image_tag(item.image.url, class: 'media-object'), item.image.url, target: '_blank' %>
   <figcaption class="media-heading">
     <div class="item_<%= item.id %>">
-      <h1><%= item.title %></h1>
+      <h1><%= link_to item.title, item_path(item) %></h1>
       <h2>$<%= item.price %></h2>
       <p><%= item.description %></p>
       <%= button_to "Add Item", carts_path(item_id: item) %>
@@ -12,16 +12,5 @@
     <%= button_to "Add to Cart", carts_path(item_id: item.id), class: "add_item_#{item.id}" %>
   <% else %>
     <p>Accessory Retired</p>
-  <% end %>
-  <% if current_admin? %>
-    <div class="item-<%= item.id %>">
-      <%= item.status %>
-      <%= link_to "Edit", edit_admin_item_path(item) %>
-      <% if item.active? %>
-        <%= link_to 'Retire', admin_item_path(item, item: {status: 'retired'}), method: :patch %>
-      <% elsif item.retired? %>
-        <%= link_to 'Reactivate', admin_item_path(item, item: {status: 'active'}), method: :patch %>
-      <% end %>
-    </div>
   <% end %>
 </figure>

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -18,10 +18,10 @@
       <%= item.status %>
       <%= link_to "Edit", admin_bike_shop_edit_path(item) %>
       <% if item.active? %>
-        <%= link_to "Retire", admin_bike_shop_path(item[:status] = 0), method: :patch %>
+        <%= link_to 'Retire', admin_bike_shop_path(item, status: 1), method: :patch %>
       <% elsif item.retired? %>
-        <%= link_to "Reactivate", admin_bike_shop_path(item[:status] = 1), method: :patch %>
+        <%= link_to 'Reactivate', admin_bike_shop_path(item, status: 0), method: :patch %>
       <% end %>
-  </div>
+    </div>
   <% end %>
 </figure>

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -16,11 +16,11 @@
   <% if current_admin? %>
     <div class="item-<%= item.slug %>">
       <%= item.status %>
-      <%= link_to "Edit", admin_bike_shop_edit_path(item) %>
+      <%= link_to "Edit", edit_admin_item_path(item) %>
       <% if item.active? %>
-        <%= link_to 'Retire', admin_bike_shop_path(item, status: 1), method: :patch %>
+        <%= link_to 'Retire', admin_item_path(item, item: {status: 'retired'}), method: :patch %>
       <% elsif item.retired? %>
-        <%= link_to 'Reactivate', admin_bike_shop_path(item, status: 0), method: :patch %>
+        <%= link_to 'Reactivate', admin_item_path(item, item: {status: 'active'}), method: :patch %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -17,7 +17,11 @@
     <div class="item-<%= item.slug %>">
       <%= item.status %>
       <%= link_to "Edit", admin_bike_shop_edit_path(item) %>
-      <%= link_to "Delete", admin_bike_shop_path(item), method: :delete %>
+      <% if item.active? %>
+        <%= link_to "Retire", admin_bike_shop_path(item[:status] = 0), method: :patch %>
+      <% elsif item.retired? %>
+        <%= link_to "Reactivate", admin_bike_shop_path(item[:status] = 1), method: :patch %>
+      <% end %>
   </div>
   <% end %>
 </figure>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,3 +1,2 @@
 <h1>Bike Shop</h1>
-
 <%= render @items %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,4 +8,4 @@
   <% end %>
 </ul>
 <button type="button" class="btn btn-warning"><%= link_to "Edit", edit_user_path(current_user) %></button>
-<%= link_to 'Bike Shop Accessories', admin_bike_shop_path %>
+<%= link_to 'Bike Shop Accessories', admin_items_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
     resources :stations, except: [:index, :show], param: :name
     resources :trips, only: [:new, :edit, :update, :destroy, :create]
     resources :users, only: [:show]
-    resources :items, except: [:destroy], path: 'bike-shop'
+    resources :items, except: [:destroy, :show], path: 'bike-shop'
   end
 
   resources :conditions, only: [:index, :show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,6 @@ Rails.application.routes.draw do
     get 'bike-shop/new', to: 'items#new'
     get 'bike-shop/edit', to: 'items#edit'
     put 'bike-shop/:title', to: 'items#update'
-    delete 'bike-shop/:title', to: 'items#destroy'
   end
 
   resources :conditions, only: [:index, :show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,9 +5,8 @@ Rails.application.routes.draw do
     resources :conditions, only: [:new, :create, :edit, :update, :destroy]
     resources :stations, except: [:index, :show], param: :name
     resources :trips, only: [:new, :edit, :update, :destroy, :create]
-    resources :items, only: [:create]
     resources :users, only: [:show]
-    resources :items, as: 'bike_shop', only: [:new, :edit, :update], params: :title
+    resources :items, except: [:destroy], path: 'bike-shop', param: :title
   end
 
   resources :conditions, only: [:index, :show]
@@ -17,6 +16,7 @@ Rails.application.routes.draw do
   resources :orders, only: [:create, :show]
   resources :carts, only: [:create, :show]
   patch "/remove_item", to: "carts#remove_item"
+  resources :items, path: 'bike-shop', only: [:show, :index], param: :title
 
   get "/dashboard", to: "users#show"
   get "/cart", to: "carts#index"
@@ -28,12 +28,9 @@ Rails.application.routes.draw do
   get '/stations-dashboard', to: 'stations#dashboard'
   get '/map', to: "conditions#map"
   get '/stations-dashboard', to: 'stations#dashboard'
-  get 'bike-shop', to: 'items#index'
-  get 'bike-shop/:title', to: 'items#show'
 
   scope :admin, as: :admin do
     get '/dashboard', to: 'users#show'
-    get '/bike-shop', to: 'items#index'
   end
 
   get '/:name', to: 'stations#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,9 +7,7 @@ Rails.application.routes.draw do
     resources :trips, only: [:new, :edit, :update, :destroy, :create]
     resources :items, only: [:create]
     resources :users, only: [:show]
-    get 'bike-shop/new', to: 'items#new'
-    get 'bike-shop/edit', to: 'items#edit'
-    put 'bike-shop/:title', to: 'items#update'
+    resources :items, as: 'bike_shop', only: [:new, :edit, :update], params: :title
   end
 
   resources :conditions, only: [:index, :show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
     resources :stations, except: [:index, :show], param: :name
     resources :trips, only: [:new, :edit, :update, :destroy, :create]
     resources :users, only: [:show]
-    resources :items, except: [:destroy], path: 'bike-shop', param: :title
+    resources :items, except: [:destroy], path: 'bike-shop'
   end
 
   resources :conditions, only: [:index, :show]
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
   resources :orders, only: [:create, :show]
   resources :carts, only: [:create, :show]
   patch "/remove_item", to: "carts#remove_item"
-  resources :items, path: 'bike-shop', only: [:show, :index], param: :title
+  resources :items, path: 'bike-shop', only: [:show, :index]
 
   get "/dashboard", to: "users#show"
   get "/cart", to: "carts#index"

--- a/db/migrate/20180222015400_create_items.rb
+++ b/db/migrate/20180222015400_create_items.rb
@@ -2,7 +2,7 @@ class CreateItems < ActiveRecord::Migration[5.1]
   def change
     create_table :items do |t|
       t.string :title
-      t.integer :status, default: 0
+      t.string :status, default: 'active'
       t.text :description
       t.decimal :price
     end

--- a/db/migrate/20180224203101_add_slug_to_items.rb
+++ b/db/migrate/20180224203101_add_slug_to_items.rb
@@ -1,5 +1,0 @@
-class AddSlugToItems < ActiveRecord::Migration[5.1]
-  def change
-    add_column :items, :slug, :string
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180224203101) do
+ActiveRecord::Schema.define(version: 20180224202536) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,14 +41,13 @@ ActiveRecord::Schema.define(version: 20180224203101) do
 
   create_table "items", force: :cascade do |t|
     t.string "title"
-    t.integer "status", default: 0
+    t.string "status", default: "active"
     t.text "description"
     t.decimal "price"
     t.string "image_file_name"
     t.string "image_content_type"
     t.integer "image_file_size"
     t.datetime "image_updated_at"
-    t.string "slug"
   end
 
   create_table "order_items", force: :cascade do |t|

--- a/spec/features/admin/items/admin_edits_an_item_spec.rb
+++ b/spec/features/admin/items/admin_edits_an_item_spec.rb
@@ -11,16 +11,13 @@ context 'As an admin' do
     scenario 'I can edit that item' do
       visit admin_items_path
 
-      within(".item-#{@active.id}") do
-        click_link('Edit')
-      end
+      find(".edit-#{@active.id}").click
 
       fill_in 'item[title]', with: 'Bike Light'
       fill_in 'item[description]', with: 'Drivers Can See You'
       fill_in 'item[price]', with: 20.00
       click_on 'Update Accessory'
 
-      expect(current_path).to eq(admin_item_path(@active))
       expect(page).to have_content('Bike Light')
       expect(page).to have_content('Drivers Can See You')
       expect(page).to have_content(20.00)
@@ -31,30 +28,25 @@ context 'As an admin' do
       visit admin_items_path
       expect(@active.status).to eq('active')
 
-      within(".item-#{@active.id}") do
-        click_link('Retire')
-      end
+      find(".retire-#{@active.id}").click
 
-      within(".item-#{@active.id}") do
-        expect(page).to have_content('retired')
-        expect(page).to have_link('Reactivate')
-      end
+      expect(page).to have_content('retired')
+      expect(page).to have_link('Reactivate')
     end
   end
 
   describe 'when I visit admin bike-shop path and click reactivate next to a retired item' do
     scenario 'I can reactivate that item' do
       visit admin_items_path
+
       expect(@retired.status).to eq('retired')
+      expect(page).to have_content('retired')
+      expect(page).to have_link('Reactivate')
 
-      within(".item-#{@retired.id}") do
-        click_link('Reactivate')
-      end
+      find(".reactivate-#{@retired.id}").click
 
-      within(".item-#{@retired.id}") do
-        expect(page).to have_content('active')
-        expect(page).to have_link('Retire')
-      end
+      expect(page).to_not have_content('retired')
+      expect(page).to_not have_link('Reactivate')
     end
   end
 end

--- a/spec/features/admin/items/admin_edits_an_item_spec.rb
+++ b/spec/features/admin/items/admin_edits_an_item_spec.rb
@@ -5,18 +5,37 @@ context 'As an admin' do
     admin = create(:admin)
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
     @active = create(:item)
-    @retired = create(:item, status: 1)
+    @retired = create(:item, status: 'retired')
+  end
+  describe 'when I visit admin bike-shop path and click edit, fill in the info and submit' do
+    scenario 'I can edit that item' do
+      visit admin_items_path
+
+      within(".item-#{@active.id}") do
+        click_link('Edit')
+      end
+
+      fill_in 'item[title]', with: 'Bike Light'
+      fill_in 'item[description]', with: 'Drivers Can See You'
+      fill_in 'item[price]', with: 20.00
+      click_on 'Update Accessory'
+
+      expect(current_path).to eq(admin_item_path(@active))
+      expect(page).to have_content('Bike Light')
+      expect(page).to have_content('Drivers Can See You')
+      expect(page).to have_content(20.00)
+    end
   end
   describe 'when I visit admin bike-shop path and click retire next to an item' do
     scenario 'I can retire that item' do
       visit admin_items_path
       expect(@active.status).to eq('active')
 
-      within(".item-#{@active.slug}") do
+      within(".item-#{@active.id}") do
         click_link('Retire')
       end
 
-      within(".item-#{@active.slug}") do
+      within(".item-#{@active.id}") do
         expect(page).to have_content('retired')
         expect(page).to have_link('Reactivate')
       end
@@ -28,11 +47,11 @@ context 'As an admin' do
       visit admin_items_path
       expect(@retired.status).to eq('retired')
 
-      within(".item-#{@retired.slug}") do
+      within(".item-#{@retired.id}") do
         click_link('Reactivate')
       end
 
-      within(".item-#{@retired.slug}") do
+      within(".item-#{@retired.id}") do
         expect(page).to have_content('active')
         expect(page).to have_link('Retire')
       end

--- a/spec/features/admin/items/admin_edits_an_item_spec.rb
+++ b/spec/features/admin/items/admin_edits_an_item_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
 context 'As an admin' do
+  before(:each) do
+    admin = create(:admin)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+    @active = create(:item)
+    @retired = create(:item, status: 1)
+  end
   describe 'when I visit admin bike-shop path and click retire next to an item' do
-    before(:each) do
-      admin = create(:admin)
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
-      @active = create(:item)
-      @retired = create(:item, status: 1)
-    end
     scenario 'I can retire that item' do
       visit admin_items_path
       expect(@active.status).to eq('active')
@@ -19,6 +19,22 @@ context 'As an admin' do
       within(".item-#{@active.slug}") do
         expect(page).to have_content('retired')
         expect(page).to have_link('Reactivate')
+      end
+    end
+  end
+
+  describe 'when I visit admin bike-shop path and click reactivate next to a retired item' do
+    scenario 'I can reactivate that item' do
+      visit admin_items_path
+      expect(@retired.status).to eq('retired')
+
+      within(".item-#{@retired.slug}") do
+        click_link('Reactivate')
+      end
+
+      within(".item-#{@retired.slug}") do
+        expect(page).to have_content('active')
+        expect(page).to have_link('Retire')
       end
     end
   end

--- a/spec/features/admin/items/admin_edits_an_item_spec.rb
+++ b/spec/features/admin/items/admin_edits_an_item_spec.rb
@@ -16,7 +16,10 @@ context 'As an admin' do
         click_link('Retire')
       end
 
-      expect(@active.status).to eq('retired')
+      within(".item-#{@active.slug}") do
+        expect(page).to have_content('retired')
+        expect(page).to have_link('Reactivate')
+      end
     end
   end
 end

--- a/spec/features/admin/items/admin_edits_an_item_spec.rb
+++ b/spec/features/admin/items/admin_edits_an_item_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+context 'As an admin' do
+  describe 'when I visit admin bike-shop path and click retire next to an item' do
+    before(:each) do
+      admin = create(:admin)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+      @active = create(:item)
+      @retired = create(:item, status: 1)
+    end
+    scenario 'I can retire that item' do
+      visit admin_bike_shop_path
+      expect(@active.status).to eq('active')
+
+      within(".item-#{@active.slug}") do
+        click_on('Retire')
+      end
+
+      expect(@active.status).to eq('retired')
+    end
+  end
+end

--- a/spec/features/admin/items/admin_edits_an_item_spec.rb
+++ b/spec/features/admin/items/admin_edits_an_item_spec.rb
@@ -9,11 +9,11 @@ context 'As an admin' do
       @retired = create(:item, status: 1)
     end
     scenario 'I can retire that item' do
-      visit admin_bike_shop_path
+      visit admin_items_path
       expect(@active.status).to eq('active')
 
       within(".item-#{@active.slug}") do
-        click_on('Retire')
+        click_link('Retire')
       end
 
       expect(@active.status).to eq('retired')

--- a/spec/features/admin/items/admin_sees_admin_dashboard_spec.rb
+++ b/spec/features/admin/items/admin_sees_admin_dashboard_spec.rb
@@ -32,7 +32,7 @@ context 'As an admin' do
         expect(page).to have_content(accessory.description)
         within(".item-#{accessory.slug}") do
           expect(page).to have_link("Edit")
-          expect(page).to have_link("Retire")
+          expect(page).to have_button("Retire")
           expect(page).to have_content(accessory.status)
         end
       end
@@ -44,7 +44,7 @@ context 'As an admin' do
       click_link 'Bike Shop Accessories'
 
       within(".item-#{@accessories.first.slug}") do
-        expect(page).to have_link('Reactivate')
+        expect(page).to have_button('Reactivate')
       end
     end
   end

--- a/spec/features/admin/items/admin_sees_admin_dashboard_spec.rb
+++ b/spec/features/admin/items/admin_sees_admin_dashboard_spec.rb
@@ -30,7 +30,7 @@ context 'As an admin' do
         expect(page).to have_xpath("//img[contains(@src,'#{item.image.url}')]")
         expect(page).to have_content(item.title)
         expect(page).to have_content(item.description)
-        within(".item-#{item.slug}") do
+        within(".item-#{item.id}") do
           expect(page).to have_link("Edit")
           expect(page).to have_link("Retire")
           expect(page).to have_content(item.status)
@@ -39,11 +39,11 @@ context 'As an admin' do
     end
 
     scenario 'I see a link to reactivate an item if the item is retired' do
-      @accessories.first.retired!
+      @accessories.first.update(status: 'retired')
       visit admin_dashboard_path
       click_link 'Bike Shop Accessories'
 
-      within(".item-#{@accessories.first.slug}") do
+      within(".item-#{@accessories.first.id}") do
         expect(page).to have_link('Reactivate')
       end
     end

--- a/spec/features/admin/items/admin_sees_admin_dashboard_spec.rb
+++ b/spec/features/admin/items/admin_sees_admin_dashboard_spec.rb
@@ -18,7 +18,7 @@ context 'As an admin' do
         visit admin_dashboard_path
         click_link 'Bike Shop Accessories'
 
-        expect(current_path).to eq(admin_bike_shop_path)
+        expect(current_path).to eq('/admin/bike-shop')
       end
     end
 
@@ -26,14 +26,14 @@ context 'As an admin' do
       visit admin_dashboard_path
       click_link 'Bike Shop Accessories'
 
-      @accessories.each do |accessory|
-        expect(page).to have_xpath("//img[contains(@src,'#{accessory.image.url}')]")
-        expect(page).to have_content(accessory.title)
-        expect(page).to have_content(accessory.description)
-        within(".item-#{accessory.slug}") do
+      @accessories.each do |item|
+        expect(page).to have_xpath("//img[contains(@src,'#{item.image.url}')]")
+        expect(page).to have_content(item.title)
+        expect(page).to have_content(item.description)
+        within(".item-#{item.slug}") do
           expect(page).to have_link("Edit")
-          expect(page).to have_button("Retire")
-          expect(page).to have_content(accessory.status)
+          expect(page).to have_link("Retire")
+          expect(page).to have_content(item.status)
         end
       end
     end
@@ -44,7 +44,7 @@ context 'As an admin' do
       click_link 'Bike Shop Accessories'
 
       within(".item-#{@accessories.first.slug}") do
-        expect(page).to have_button('Reactivate')
+        expect(page).to have_link('Reactivate')
       end
     end
   end

--- a/spec/features/admin/items/admin_sees_admin_dashboard_spec.rb
+++ b/spec/features/admin/items/admin_sees_admin_dashboard_spec.rb
@@ -32,19 +32,20 @@ context 'As an admin' do
         expect(page).to have_content(accessory.description)
         within(".item-#{accessory.slug}") do
           expect(page).to have_link("Edit")
-          expect(page).to have_link("Delete")
+          expect(page).to have_link("Retire")
           expect(page).to have_content(accessory.status)
         end
       end
     end
+
+    scenario 'I see a link to reactivate an item if the item is retired' do
+      @accessories.first.retired!
+      visit admin_dashboard_path
+      click_link 'Bike Shop Accessories'
+
+      within(".item-#{@accessories.first.slug}") do
+        expect(page).to have_link('Reactivate')
+      end
+    end
   end
 end
-
-#
-# Each accessory should have:
-#
-# A thumbnail of the image
-# Description
-# Status
-# Ability to Edit accessory
-# Ability to Retire/Reactivate accessory

--- a/spec/features/admin/items/admin_sees_admin_dashboard_spec.rb
+++ b/spec/features/admin/items/admin_sees_admin_dashboard_spec.rb
@@ -30,11 +30,7 @@ context 'As an admin' do
         expect(page).to have_xpath("//img[contains(@src,'#{item.image.url}')]")
         expect(page).to have_content(item.title)
         expect(page).to have_content(item.description)
-        within(".item-#{item.id}") do
-          expect(page).to have_link("Edit")
-          expect(page).to have_link("Retire")
-          expect(page).to have_content(item.status)
-        end
+        expect(page).to have_content(item.status)
       end
     end
 
@@ -43,9 +39,7 @@ context 'As an admin' do
       visit admin_dashboard_path
       click_link 'Bike Shop Accessories'
 
-      within(".item-#{@accessories.first.id}") do
-        expect(page).to have_link('Reactivate')
-      end
+      expect(page).to have_link('Reactivate')
     end
   end
 end

--- a/spec/features/user/cart/user_sees_their_cart_spec.rb
+++ b/spec/features/user/cart/user_sees_their_cart_spec.rb
@@ -2,14 +2,14 @@ require "rails_helper"
 
 describe "as a user" do
   before :each do
-    user = create(:user)
+    @user = create(:user)
     @item1 = create(:item, title: "item1")
     @item2 = create(:item, title: "item2")
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
   end
   describe "when i visit /cart" do
     it "shows an image, title, description and price for each item in my cart" do
-      visit bike_shop_path
+      visit items_path
 
       within(".item_#{@item1.id}") do
         click_on "Add Item"
@@ -32,7 +32,7 @@ describe "as a user" do
     end
 
     it "shows subtotal and quantity of each item" do
-      visit bike_shop_path
+      visit items_path
 
       within(".item_#{@item1.id}") do
         click_on "Add Item"
@@ -54,7 +54,7 @@ describe "as a user" do
     end
 
     it "user can remove item form cart" do
-      visit bike_shop_path
+      visit items_path
 
       within(".item_#{@item1.id}") do
         click_on "Add Item"
@@ -80,7 +80,7 @@ describe "as a user" do
     end
 
     it "pluralizes accurately" do
-      visit bike_shop_path
+      visit items_path
 
       within(".item_#{@item1.id}") do
         click_on "Add Item"

--- a/spec/features/user/orders/user_can_see_order_show_spec.rb
+++ b/spec/features/user/orders/user_can_see_order_show_spec.rb
@@ -24,7 +24,7 @@ describe "as a user" do
           click_on "Add Item"
         end
 
-        expect(current_path).to eq(bike_shop_path)
+        expect(current_path).to eq(items_path)
 
         visit "/cart"
 

--- a/spec/features/visitor/items/visitor_can_remove_item_spec.rb
+++ b/spec/features/visitor/items/visitor_can_remove_item_spec.rb
@@ -1,1 +1,0 @@
-require "rails_helper"

--- a/spec/features/visitor/items/visitor_sees_a_retired_item_spec.rb
+++ b/spec/features/visitor/items/visitor_sees_a_retired_item_spec.rb
@@ -6,7 +6,7 @@ context 'As a visitor' do
       @accessory = create(:item, status: 1)
     end
     scenario 'I am still able to access the accessory page' do
-      visit "bike-shop/#{@accessory.slug}"
+      visit "bike-shop/#{@accessory.id}"
 
       expect(page).to have_content(@accessory.title)
       expect(page).to have_content(@accessory.description)
@@ -14,7 +14,7 @@ context 'As a visitor' do
     end
 
     scenario 'I am not able to add the accessory to my cart,and I see "Accessory Retired' do
-      visit "bike-shop/#{@accessory.slug}"
+      visit "bike-shop/#{@accessory.id}"
 
       expect(page).to have_content("Accessory Retired")
       expect(page).to_not have_button('Add To Cart')

--- a/spec/features/visitor/items/visitor_sees_bike-shop_spec.rb
+++ b/spec/features/visitor/items/visitor_sees_bike-shop_spec.rb
@@ -30,7 +30,7 @@ context 'As a visitor' do
         expect(page).to have_content("You now have 1 #{@accessories.first.title} in your cart")
       end
       scenario 'I also see my cart count updated on all pages' do
-        visit bike_shop_path
+        visit items_path
         expect(page).to have_content('Cart: 0')
 
         find(".add_item_#{@accessories.first.id}").click
@@ -39,7 +39,7 @@ context 'As a visitor' do
         visit root_path
         expect(page).to have_content('Cart: 1')
 
-        visit bike_shop_path
+        visit items_path
         find(".add_item_#{@accessories.last.id}").click
 
         expect(page).to have_content('Cart: 2')


### PR DESCRIPTION
<!--- General summary of changes in the Title above -->

Description of Changes:
-
* admin can edit items
* admin can retire or reactivate items
* admin can see the admin dashboard and click link to see admin dashboard path
* admin dashboard path is a table
* change bike-shop routes to just be path
*  remove enum for item status
* remove slug for items

### Tests Added:
* specs for admin sees admin dashboard
* specs for admin sees admin bikeshop
* specs for admin can edit an item

#### Reference Related Issue(s) or Spec Requirement:
- #46
<!--- To automatically close related issue(s) on merge, put "closes #<issue number>" in the Title of this request -->

#### Checklist:
- [x] Code follows code style of this project
- [x] Tests added to cover changes
- [x] All new and existing tests passing
#

#### Questions / Additional Notes:

@mgmilton @slimecog @annaroyer

<!--- AliSchlereth icorson3 --->
